### PR TITLE
Tweaking TCP connection handling to Graphite

### DIFF
--- a/src/folsom_graphite_sender.erl
+++ b/src/folsom_graphite_sender.erl
@@ -45,7 +45,7 @@ send(Message) ->
 
 init([GraphiteHost, GraphitePort]) ->
     case gen_tcp:connect(GraphiteHost, GraphitePort,
-                         [binary, raw, {active, false},
+                         [binary, {packet, raw}, {active, false},
                           {keepalive, true}, {nodelay, true},
                           {send_timeout, 2000}], ?CONNECT_TIMEOUT) of
         {ok, Socket} ->


### PR DESCRIPTION
Tuning TCP connection params to make sure data is transmitted quickly and we detect timeouts during sends to graphite.
