### PR TITLE
Support resetting metrics and flag for appending hostname.

### DIFF
--- a/src/folsom_graphite_sup.erl
+++ b/src/folsom_graphite_sup.erl
@@ -34,13 +34,16 @@ start_link() ->
 init([]) ->
     GraphiteHost = get_env(graphite_host, "localhost"),
     GraphitePort = get_env(graphite_port, 2003),
-    Prefix = get_env(prefix, "folsom"),
-    Application = get_env(application, undefined),
-    SendInterval = get_env(send_interval, 10000),
-    lager:debug("Prefix ~w", [Prefix]),
+    WorkerConfig = [{prefix, get_env(prefix, "folsom")},
+                    {application, get_env(application, undefined)},
+                    {send_interval, get_env(send_interval, 10000)},
+                    {reset_metrics, get_env(reset_metrics, false)},
+                    {append_hostname, get_env(append_hostname, true)}
+                    ],
+    lager:debug("Prefix ~w", [get_env(prefix, "folsom")]),
     {ok, {{one_for_one, 10, 3600},
           [?WORKER(folsom_graphite_sender, [GraphiteHost, GraphitePort]),
-           ?WORKER(folsom_graphite_worker, [Prefix, Application, SendInterval])]
+           ?WORKER(folsom_graphite_worker, [WorkerConfig])]
          }}.
 
 get_env(Key, Default) ->

--- a/src/folsom_graphite_worker.erl
+++ b/src/folsom_graphite_worker.erl
@@ -7,9 +7,13 @@
 -behaviour(gen_server).
 
 -include_lib("eunit/include/eunit.hrl").
+-ifdef(TEST).
+-compile([export_all]).
+-endif.
 
 -record(state, {send_interval :: integer(),
-                prefix :: string()
+                prefix :: string(),
+                extract_fold_fun :: function()
                }).
 
 -define(METER_FIELDS, [{count, "count"},
@@ -29,7 +33,7 @@
 %% API Function Exports
 %% ------------------------------------------------------------------
 
--export([start_link/3
+-export([start_link/1
         ]).
 
 %% ------------------------------------------------------------------
@@ -47,16 +51,25 @@
 %% API Function Definitions
 %% ------------------------------------------------------------------
 
-start_link(Prefix, Application, SendInterval) ->
-    gen_server:start_link(?MODULE, [Prefix, Application, SendInterval], []).
+start_link(Config) ->
+    gen_server:start_link(?MODULE, Config, []).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 
-init([Prefix, Application, SendInterval]) ->
+init(Config) ->
+    SendInterval = proplists:get_value(send_interval, Config),
+    ResetMetrics = proplists:get_value(reset_metrics, Config),
+
+    %% This function is used in publish_to_graphite.
+    ExtractFoldFun = case ResetMetrics of
+        true -> fun extract_value_and_reset/2;
+        _ ->    fun extract_value/2
+    end,
     State = #state{send_interval = SendInterval,
-                   prefix = prefix(Prefix, Application)
+                   prefix = make_prefix(Config),
+                   extract_fold_fun = ExtractFoldFun
                    },
     timer:send_after(SendInterval, publish),
     {ok, State}.
@@ -93,9 +106,9 @@ hostname() ->
     folsom_graphite_util:sanitize(Hostname).
 
 -spec publish_to_graphite(#state{}) -> ok.
-publish_to_graphite(#state{prefix = Prefix}) ->
+publish_to_graphite(#state{prefix = Prefix, extract_fold_fun = F}) ->
     Timestamp = make_timestamp(),
-    {_, _, Lines} = lists:foldl(fun extract_value/2, {Prefix, Timestamp, []}, folsom_metrics:get_metrics_info()),
+    {_, _, Lines} = lists:foldl(F, {Prefix, Timestamp, []}, folsom_metrics:get_metrics_info()),
     folsom_graphite_sender:send(Lines),
     ok.
 
@@ -114,6 +127,17 @@ extract_value({Name, [{type, counter}]}, {Prefix, Timestamp, Acc}) ->
     Value = folsom_metrics:get_metric_value(Name),
     {Prefix, Timestamp, [folsom_graphite_util:graphite_format(Prefix, Timestamp, {io_lib:format("~s.count", [Name]), Value})|Acc]}.
 
+extract_value_and_reset({Name, _} = E, A) ->
+    R = extract_value(E, A),
+    %% There is a potential race condition here.
+    %% Ideally folsom_metrics:delete_metric would
+    %% also return the values...
+    %% For now this is probably acceptable as it
+    %% is probably unlikely to encounter the race
+    %% condition.
+    folsom_metrics:delete_metric(Name),
+    R.
+
 extract_values(Name, Values, Fields, {Prefix, Timestamp, StartAcc}) ->
     {Prefix, Timestamp, lists:foldl(fun({MetricName, PrettyName}, Acc) ->
                                             V = proplists:get_value(MetricName, Values),
@@ -127,15 +151,18 @@ make_timestamp() ->
     {MegaSecs, Secs, _Microsecs} = os:timestamp(),
     integer_to_list(MegaSecs*1000000 + Secs).
 
--spec append_hostname(Prefix :: string()) -> string().
-append_hostname(Prefix) ->
-    string:join([Prefix, hostname()], ".").
-
--spec prefix(Prefix :: string(),
-             Application :: string() | undefined) -> string().
-prefix(Prefix, undefined) ->
-    append_hostname(folsom_graphite_util:sanitize(Prefix));
-prefix(Prefix, Application) ->
-    append_hostname(string:join([folsom_graphite_util:sanitize(Prefix),
-                                 folsom_graphite_util:sanitize(Application)],".")).
-
+-spec make_prefix(Config :: list()) -> string().
+make_prefix(Config) ->
+    TopPrefix = proplists:get_value(prefix, Config),
+    Application = proplists:get_value(application, Config),
+    AppendHostname = proplists:get_value(append_hostname, Config),
+    Parts = [folsom_graphite_util:sanitize(TopPrefix)]
+        ++ case Application of
+            undefined -> [];
+            _ -> [folsom_graphite_util:sanitize(Application)]
+        end
+        ++ case AppendHostname of
+            true -> [hostname()];
+            _ -> []
+        end,
+    string:join(Parts, ".").

--- a/test/folsom_graphite_worker_tests.erl
+++ b/test/folsom_graphite_worker_tests.erl
@@ -1,0 +1,29 @@
+
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @copyright 2013 Opscode Inc.
+
+-module(folsom_graphite_worker_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+make_prefix_test_() ->
+  [{"Top prefix only",
+    fun() -> Config = [{prefix, "1"}],
+             ?assertEqual("1", lists:flatten(folsom_graphite_worker:make_prefix(Config)))
+    end},
+   {"Top and app",
+    fun() -> Config = [{prefix, "1"}, {application, "2"}],
+             ?assertEqual("1.2", lists:flatten(folsom_graphite_worker:make_prefix(Config)))
+    end},
+   {"Top and append hostname",
+    fun() -> Config = [{prefix, "1"}, {append_hostname, true}],
+             Expected = string:join(["1", folsom_graphite_worker:hostname()], "."),
+             ?assertEqual(Expected, lists:flatten(folsom_graphite_worker:make_prefix(Config)))
+    end},
+   {"Top, app, and append hostname",
+    fun() -> Config = [{prefix, "1"}, {application, "2"}, {append_hostname, true}],
+             Expected = string:join(["1", "2", folsom_graphite_worker:hostname()], "."),
+             ?assertEqual(Expected, lists:flatten(folsom_graphite_worker:make_prefix(Config)))
+    end}
+  ].


### PR DESCRIPTION
In some cases it is preferable to have metrics be reset after
submitted to graphite. This allows metrics in graphite to correctly
reflect the values for the time period only.

folsom_graphite normally adds the hostname to the metric name. This
is almost always desirable, but not always. This change makes this
behavior configurable.
