### PR TITLE
Decrease MAX_RESTART_WINDOW from 3600 to 10

### DIFF
--- a/src/folsom_graphite_sup.erl
+++ b/src/folsom_graphite_sup.erl
@@ -23,7 +23,7 @@
 -define(WORKER(I, Args), {I, {I, start_link, Args}, permanent, 5000, worker, [I]}).
 -define(WORKERNL(I, Args), {I, {I, start, Args}, permanent, 5000, worker, [I]}).
 -define(MAX_RESTARTS, 10).
--define(MAX_RESTART_WINDOW, 3600).
+-define(MAX_RESTART_WINDOW, 10).
 %% ===================================================================
 %% API functions
 %% ===================================================================


### PR DESCRIPTION
The MAX_RESTART_WINDOW is used in the configuration of the supervision
tree. In the previous configuration 10 restarts in an hour would
results in the application failing. This was out of line wiht our
other supervision tree configurations which typically set the max
restart window to 10 seconds.